### PR TITLE
Feature/ displaying resolved status as icon

### DIFF
--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -33,6 +33,7 @@ module.exports = function (Topics) {
             lastposttime: 0,
             postcount: 0,
             viewcount: 0,
+            isResolved: 'active',
         };
 
         if (Array.isArray(data.tags) && data.tags.length) {

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -290,6 +290,7 @@ module.exports = function (Topics) {
     Topics.increaseViewCount = async function (tid) {
         const cid = await Topics.getTopicField(tid, 'cid');
         incrementFieldAndUpdateSortedSet(tid, 'viewcount', 1, ['topics:views', `cid:${cid}:tids:views`]);
+        //likely increments the viewcount and resorts the posts accordingly
     };
 
     async function incrementFieldAndUpdateSortedSet(tid, field, by, set) {

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -290,7 +290,6 @@ module.exports = function (Topics) {
     Topics.increaseViewCount = async function (tid) {
         const cid = await Topics.getTopicField(tid, 'cid');
         incrementFieldAndUpdateSortedSet(tid, 'viewcount', 1, ['topics:views', `cid:${cid}:tids:views`]);
-        //likely increments the viewcount and resorts the posts accordingly
     };
 
     async function incrementFieldAndUpdateSortedSet(tid, field, by, set) {

--- a/themes/nodebb-theme-persona/templates/partials/topic/stats.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/stats.tpl
@@ -10,3 +10,7 @@
     <i class="fa fa-fw fa-eye" title="[[global:views]]"></i>
     <span class="human-readable-number" title="{viewcount}">{viewcount}</span>
 </div>
+<div class="stats text-muted">
+    <i class="fa fa-fw fa-check-circle" title="Resolved"></i>
+    <span class="resolved">{status}</span>
+</div>

--- a/themes/nodebb-theme-persona/templates/partials/topic/stats.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/stats.tpl
@@ -11,6 +11,6 @@
     <span class="human-readable-number" title="{viewcount}">{viewcount}</span>
 </div>
 <div class="stats text-muted">
-    <i class="fa fa-fw fa-check-circle" title="Resolved"></i>
-    <span class="resolved">{status}</span>
+    <i class="fa fa-fw fa-check-circle" title="[[global:isResolved]]"></i>
+    <span class="isResolved" title="{isResolved}">{isResolved}</span>
 </div>


### PR DESCRIPTION
Resolves #3 
<img width="1186" alt="Screenshot 2024-02-06 at 6 53 21 PM" src="https://github.com/CMU-313/spring24-nodebb-the-capibaras/assets/107712113/852d8296-5e0a-4701-84df-7e967f614014">

I added the checkmark icon as shown above and initialized it in the create.js file

themes/nodebb-theme-persona/templates/partials/topic/stats.tpl

- To add another icon next to the eye and pencil icon

src/topics/create.js

- initalizing a isResolved variable  to be ‘active’
- now defining this variable as a string instead of boolean
- This variable would to take on the values of ‘active’ and ‘resolved’