### PR TITLE
Backend tagging

### DIFF
--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -141,6 +141,18 @@ topicsAPI.unlock = async function (caller, data) {
     });
 };
 
+topicsAPI.resolve = async function (caller, data) {
+    await doTopicAction('resolve', 'event:topic_resolved', caller, {
+        tids: data.tids,
+    });
+};
+
+topicsAPI.unResolve = async function (caller, data) {
+    await doTopicAction('active', 'event:topic_unResolved', caller, {
+        tids: data.tids,
+    });
+};
+
 topicsAPI.follow = async function (caller, data) {
     await topics.follow(data.tid, caller.uid);
 };

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -12,7 +12,7 @@ const intFields = [
     'tid', 'cid', 'uid', 'mainPid', 'postcount',
     'viewcount', 'postercount', 'deleted', 'locked', 'pinned',
     'pinExpiry', 'timestamp', 'upvotes', 'downvotes', 'lastposttime',
-    'deleterUid',
+    'deleterUid', 'resolved',
 ];
 
 module.exports = function (Topics) {

--- a/src/topics/events.js
+++ b/src/topics/events.js
@@ -39,6 +39,14 @@ Events._types = {
         icon: 'fa-unlock',
         text: '[[topic:unlocked-by]]',
     },
+    resolve: {
+        icon: 'fa-resolve',
+        text: '[[topic:solved-by]]',
+    },
+    unResolve: {
+        icon: 'fa-unResolve',
+        text: '[[topic:unSolved-by]]',
+    },
     delete: {
         icon: 'fa-trash',
         text: '[[topic:deleted-by]]',

--- a/src/topics/index.js
+++ b/src/topics/index.js
@@ -268,8 +268,8 @@ async function getMainPosts(mainPids, uid) {
     return await Topics.addPostData(postData, uid);
 }
 
-// retrive whether isLocked truth value by accessing the 'locked' field of 
-// topic with tid by using Topics.getTopicField(tid, 'locked');
+//  retrive whether isLocked truth value by accessing the 'locked' field of
+//  topic with tid by using Topics.getTopicField(tid, 'locked');
 Topics.isLocked = async function (tid) {
     const locked = await Topics.getTopicField(tid, 'locked');
     // console.log("im called here Topics.isLocked");//it's not printed out

--- a/src/topics/index.js
+++ b/src/topics/index.js
@@ -268,9 +268,17 @@ async function getMainPosts(mainPids, uid) {
     return await Topics.addPostData(postData, uid);
 }
 
+// retrive whether isLocked truth value by accessing the 'locked' field of 
+// topic with tid by using Topics.getTopicField(tid, 'locked');
 Topics.isLocked = async function (tid) {
     const locked = await Topics.getTopicField(tid, 'locked');
+    console.log("im called here Topics.isLocked");//it's not printed out
     return locked === 1;
+};
+
+Topics.isResolved = async function (tid) {
+    const resolved = await Topics.getTopicField(tid, 'resolved');
+    return resolved === 1;
 };
 
 Topics.search = async function (tid, term) {

--- a/src/topics/index.js
+++ b/src/topics/index.js
@@ -272,7 +272,7 @@ async function getMainPosts(mainPids, uid) {
 // topic with tid by using Topics.getTopicField(tid, 'locked');
 Topics.isLocked = async function (tid) {
     const locked = await Topics.getTopicField(tid, 'locked');
-    console.log("im called here Topics.isLocked");//it's not printed out
+    // console.log("im called here Topics.isLocked");//it's not printed out
     return locked === 1;
 };
 

--- a/src/topics/tools.js
+++ b/src/topics/tools.js
@@ -12,7 +12,7 @@ const utils = require('../utils');
 
 
 module.exports = function (Topics) {
-    const topicTools = {}; //new variable
+    const topicTools = {};//    new variable
     Topics.tools = topicTools;
 
     topicTools.delete = async function (tid, uid) {
@@ -110,15 +110,15 @@ module.exports = function (Topics) {
         return topicData;
     }
 
-    //added
+
     topicTools.markAsIsResolved = async function (tid, uid) {
         return await toggleResolved(tid, uid, true);
     };
-    //added
+
     topicTools.unmarkResolved = async function (tid, uid) {
         return await toggleResolved(tid, uid, false);
     };
-    //added
+
     async function toggleResolved(tid, uid, resolve) {
         const topicData = await Topics.getTopicFields(tid, ['tid', 'uid', 'cid']);
         if (!topicData || !topicData.cid) {
@@ -128,11 +128,10 @@ module.exports = function (Topics) {
         if (!isAdminOrMod) {
             throw new Error('[[error:no-privileges]]');
         }
-        await Topics.setTopicField(tid, 'resolved', resolve ? 1 : 0); 
-        //set resolved field to 1/0 based on the second attribute of unmarkResolved
+        await Topics.setTopicField(tid, 'resolved', resolve ? 1 : 0);// set resolved field to 1/0 based on the second attribute of unmarkResolved
         topicData.events = await Topics.events.log(tid, { type: resolve ? 'resolved' : 'active', uid });
-        topicData.isResolved = resolve; // deprecate in v2.0
-        topicData.resolved = resolve; //resolve field is true or false
+        topicData.isResolved = resolve;// deprecate in v2.0
+        topicData.resolved = resolve;// resolve field is true or false
 
         plugins.hooks.fire('action:topic.resolve', { topic: _.clone(topicData), uid: uid });
         return topicData;

--- a/src/topics/tools.js
+++ b/src/topics/tools.js
@@ -134,7 +134,7 @@ module.exports = function (Topics) {
         topicData.isResolved = resolve; // deprecate in v2.0
         topicData.resolved = resolve; //resolve field is true or false
 
-        plugins.hooks.fire('action:topic.lock', { topic: _.clone(topicData), uid: uid });
+        plugins.hooks.fire('action:topic.resolve', { topic: _.clone(topicData), uid: uid });
         return topicData;
     }
 

--- a/src/types/topic.ts
+++ b/src/types/topic.ts
@@ -55,6 +55,7 @@ export type TopicSlimProperties = {
   deleterUid: string;
   titleRaw: string;
   locked: string;
+  resolved: string;
   pinned: number;
   timestamp: string;
   timestampISO: number;


### PR DESCRIPTION
I've added a tagging feature to the backend and made the below changes:
- src/api/topics.js
added 'resolve' and 'unResolve' to topicsAPI for use in other files

- src/topics/events.js
appended custom event types 'resolve' and 'unResolve' so that it will allow logging a custom topic event 'toggleResolved' by calling `topics.events.log(tid, { 'resolve', uid }) in src/topics/tools.js

- src/topics/index.js
added 'isResolved' attribute to topics object, which will then return whether a topic is marked as resolved given the topic id when called

- src/topics/tools.js
added helper functions 'markAsIsResolved' and 'unmarkResolved' to use in src/posts.js

- src/types/topics.js
added TopicSlimProperties of 'resolved'