### PR TITLE
Testing for marking resolved and unresolved

### DIFF
--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -141,14 +141,14 @@ topicsAPI.unlock = async function (caller, data) {
     });
 };
 
-topicsAPI.resolve = async function (caller, data) {
-    await doTopicAction('resolve', 'event:topic_resolved', caller, {
+topicsAPI.resolved = async function (caller, data) {
+    await doTopicAction('resolved', 'event:topic_resolved', caller, {
         tids: data.tids,
     });
 };
 
 topicsAPI.unResolve = async function (caller, data) {
-    await doTopicAction('active', 'event:topic_unResolved', caller, {
+    await doTopicAction('unResolved', 'event:topic_unResolved', caller, {
         tids: data.tids,
     });
 };

--- a/src/topics/events.js
+++ b/src/topics/events.js
@@ -39,11 +39,11 @@ Events._types = {
         icon: 'fa-unlock',
         text: '[[topic:unlocked-by]]',
     },
-    resolve: {
-        icon: 'fa-resolve',
+    resolved: {
+        icon: 'fa-resolved',
         text: '[[topic:solved-by]]',
     },
-    unResolve: {
+    unResolved: {
         icon: 'fa-unResolve',
         text: '[[topic:unSolved-by]]',
     },

--- a/src/topics/tools.js
+++ b/src/topics/tools.js
@@ -111,15 +111,15 @@ module.exports = function (Topics) {
     }
 
 
-    topicTools.markAsIsResolved = async function (tid, uid) {
+    topicTools.resolved = async function (tid, uid) {
         return await toggleResolved(tid, uid, true);
     };
 
-    topicTools.unmarkResolved = async function (tid, uid) {
+    topicTools.unResolved = async function (tid, uid) {
         return await toggleResolved(tid, uid, false);
     };
 
-    async function toggleResolved(tid, uid, resolve) {
+    async function toggleResolved(tid, uid, resolved) {
         const topicData = await Topics.getTopicFields(tid, ['tid', 'uid', 'cid']);
         if (!topicData || !topicData.cid) {
             throw new Error('[[error:no-topic]]');
@@ -128,12 +128,12 @@ module.exports = function (Topics) {
         if (!isAdminOrMod) {
             throw new Error('[[error:no-privileges]]');
         }
-        await Topics.setTopicField(tid, 'resolved', resolve ? 1 : 0);// set resolved field to 1/0 based on the second attribute of unmarkResolved
-        topicData.events = await Topics.events.log(tid, { type: resolve ? 'resolved' : 'active', uid });
-        topicData.isResolved = resolve;// deprecate in v2.0
-        topicData.resolved = resolve;// resolve field is true or false
+        await Topics.setTopicField(tid, 'resolved', resolved ? 1 : 0);// set resolved field to 1/0 based on the second attribute of unmarkResolved
+        topicData.events = await Topics.events.log(tid, { type: resolved ? 'resolved' : 'unResolved', uid });
+        topicData.isResolved = resolved;// deprecate in v2.0
+        topicData.resolved = resolved;// resolved field is true or false
 
-        plugins.hooks.fire('action:topic.resolve', { topic: _.clone(topicData), uid: uid });
+        plugins.hooks.fire('action:topic.resolved', { topic: _.clone(topicData), uid: uid });
         return topicData;
     }
 

--- a/test/topics.js
+++ b/test/topics.js
@@ -678,6 +678,18 @@ describe('Topic\'s', () => {
             assert(!isLocked);
         });
 
+        it('should mark topic as resolved', async () => {
+            await apiTopics.resolved({ uid: adminUid }, { tids: [newTopic.tid], cid: categoryObj.cid });
+            const isResolved = await topics.isResolved(newTopic.tid);
+            assert(isResolved);
+        });
+
+        it('should mark topic as unresolved', async () => {
+            await apiTopics.unResolve({ uid: adminUid }, { tids: [newTopic.tid], cid: categoryObj.cid });
+            const isResolved = await topics.isResolved(newTopic.tid);
+            assert(!isResolved);
+        });
+
         it('should pin topic', async () => {
             await apiTopics.pin({ uid: adminUid }, { tids: [newTopic.tid], cid: categoryObj.cid });
             const pinned = await topics.getTopicField(newTopic.tid, 'pinned');


### PR DESCRIPTION
Changed some methods/variables that set post as resolved to "resolved"

and those that set posts as unresolved as "unResolve"

Added test cases for each case in which post is marked as unresolved and when it is marked as resolved


